### PR TITLE
Notification override

### DIFF
--- a/android/src/main/java/com/webengage/webengage_plugin/FlutterInAppCallbacks.java
+++ b/android/src/main/java/com/webengage/webengage_plugin/FlutterInAppCallbacks.java
@@ -12,6 +12,16 @@ import static com.webengage.webengage_plugin.Constants.MethodName.*;
 
 
 public class FlutterInAppCallbacks implements InAppNotificationCallbacks {
+    boolean overrideClickAction;
+
+    FlutterInAppCallbacks() {
+        this.overrideClickAction = false;
+    }
+
+    FlutterInAppCallbacks(boolean overrideClickAction) {
+        this.overrideClickAction = overrideClickAction;
+    }
+
     @Override
     public InAppNotificationData onInAppNotificationPrepared(Context context, InAppNotificationData inAppNotificationData) {
         WebEngagePlugin.sendOrQueueCallback(METHOD_NAME_ON_INAPP_PREPARED,
@@ -30,7 +40,7 @@ public class FlutterInAppCallbacks implements InAppNotificationCallbacks {
         Map<String, Object> map = Utils.jsonObjectToMap(inAppNotificationData.getData());
         map.put(SELECTED_ACTION_ID, s);
         WebEngagePlugin.sendOrQueueCallback(METHOD_NAME_ON_INAPP_CLICKED, map);
-        return false;
+        return overrideClickAction;
     }
 
     @Override

--- a/android/src/main/java/com/webengage/webengage_plugin/WebEngagePlugin.java
+++ b/android/src/main/java/com/webengage/webengage_plugin/WebEngagePlugin.java
@@ -64,6 +64,10 @@ public class WebEngagePlugin implements FlutterPlugin, MethodCallHandler, Activi
 
     @Override
     public void onMethodCall(MethodCall call, Result result) {
+        if (call.method.equals("getPlatformVersion")) {
+            result.success("Android " + android.os.Build.VERSION.RELEASE);
+            return;
+        }
         switch (call.method) {
             case METHOD_NAME_SET_USER_LOGIN: {
                 userLogin(call, result);
@@ -175,13 +179,12 @@ public class WebEngagePlugin implements FlutterPlugin, MethodCallHandler, Activi
                 setUserListAttribute(call, result);
                 break;
             }
+            default:
+                result.notImplemented();
+                return;
         }
 
-        if (call.method.equals("getPlatformVersion")) {
-            result.success("Android " + android.os.Build.VERSION.RELEASE);
-        } else {
-            result.notImplemented();
-        }
+        result.success(true);
     }
 
     private void setUserMapAttribute(MethodCall call, Result result) {

--- a/android/src/main/java/com/webengage/webengage_plugin/WebengageInitializer.java
+++ b/android/src/main/java/com/webengage/webengage_plugin/WebengageInitializer.java
@@ -13,4 +13,10 @@ public class WebengageInitializer {
         WebEngage.registerInAppNotificationCallback(new FlutterInAppCallbacks());
         application.registerActivityLifecycleCallbacks(new WebEngageActivityLifeCycleCallbacks(application.getApplicationContext(), config));
     }
+
+    public static void initialize(Application application, WebEngageConfig config, boolean overrideClickAction) {
+        WebEngage.registerPushNotificationCallback(new FlutterPushMessageCallback());
+        WebEngage.registerInAppNotificationCallback(new FlutterInAppCallbacks(overrideClickAction));
+        application.registerActivityLifecycleCallbacks(new WebEngageActivityLifeCycleCallbacks(application.getApplicationContext(), config));
+    }
 }


### PR DESCRIPTION
Adding a provision to override notification click. This will allow handling notification Deeplink in the Flutter itself instead of opening Deeplink in the browser and again launch a deep link inside the app.